### PR TITLE
Fix generating client auth tokens. Add test.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,18 @@
 			<artifactId>httpmime</artifactId>
 			<version>4.5</version>
 		</dependency>
+                <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                        <version>4.12</version>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-junit</artifactId>
+                        <version>2.0.0.0</version>
+                        <scope>test</scope>
+                </dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/main/java/com/ziggeo/ZiggeoAuth.java
+++ b/src/main/java/com/ziggeo/ZiggeoAuth.java
@@ -37,8 +37,8 @@ public class ZiggeoAuth {
 		byte[] hashed_key = md.digest();
 		Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5padding");
 		SecretKeySpec skeySpec = new SecretKeySpec(hashed_key, "AES");
-		cipher.init(Cipher.ENCRYPT_MODE, skeySpec, new IvParameterSpec(
-				new byte[8]));
+                cipher.init(Cipher.ENCRYPT_MODE, skeySpec,
+                            new IvParameterSpec(new byte[16]));
 		byte[] encrypted = cipher.doFinal(plaintext.getBytes());
 		return Base64.getEncoder().encodeToString(encrypted);
 	}

--- a/src/test/java/com/ziggeo/ClientAuthTest.java
+++ b/src/test/java/com/ziggeo/ClientAuthTest.java
@@ -1,0 +1,30 @@
+package com.ziggeo;
+
+import org.json.*;
+import javax.crypto.*;
+import java.security.*;
+import com.ziggeo.Ziggeo;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.isA;
+
+public class ClientAuthTest {
+
+    protected Ziggeo apiClient;
+
+    @Before
+    public void setUp() {
+        apiClient = new Ziggeo("token", "private_key", "encryption_key");
+    }
+
+    @Test
+    public void testGenerate() throws
+        NoSuchAlgorithmException, InvalidKeyException, NoSuchPaddingException,
+        InvalidAlgorithmParameterException, IllegalBlockSizeException,
+        BadPaddingException {
+        JSONObject data = new JSONObject("{\"key\": \"value\"}");
+        assertThat(apiClient.auth().generate(data), isA(String.class));
+    }
+}


### PR DESCRIPTION
Generating client auth tokens seems to be broken, at least on my machine. It will blow up with an exception saying that the initialisation vector does not have the correct length.

I have added two dependencies to the project and one test, to test the correct behaviour.

I have also sent an email to support outlining the bug and discussing a few other related matters.
